### PR TITLE
A few more tiny patches

### DIFF
--- a/driver/src/fancontrol.c
+++ b/driver/src/fancontrol.c
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "fancontrol.h"
 
-int get_max_fan_rpm(__u32 product_id)
+/*
+ * Returns the highest valid fan RPM for manual fan control
+ *
+ * We could through a higher value at the EC, it may even accept it which would
+ * be dangerous, so limit it to what we know is safe based on using Synapse.
+ *
+ * Each model of Blade seems to have a different upper limit, so we require the
+ * product ID to set the correct upper bound
+ */
+static int get_max_fan_rpm(__u32 product_id)
 {
 	switch (product_id) {
 	case BLADE_2018_ADV:

--- a/driver/src/fancontrol.c
+++ b/driver/src/fancontrol.c
@@ -16,16 +16,16 @@ int get_max_fan_rpm(__u32 product_id)
 	}
 }
 
-__u8 clampFanRPM(unsigned int rpm, __u32 product_id)
+u8 clampFanRPM(unsigned int rpm, __u32 product_id)
 {
 	int max_allowed = get_max_fan_rpm(product_id);
 
 	if (rpm > max_allowed)
-		return (__u8) (max_allowed / 100);
+		return (u8)(max_allowed / 100);
 	else if (rpm < ABSOLUTE_MIN_FAN_RPM)
-		return (__u8) (ABSOLUTE_MIN_FAN_RPM / 100);
+		return (u8)(ABSOLUTE_MIN_FAN_RPM / 100);
 
-	return (__u8) (rpm / 100);
+	return (u8)(rpm / 100);
 }
 
 int creatorModeAllowed(__u32 product_id)

--- a/driver/src/fancontrol.c
+++ b/driver/src/fancontrol.c
@@ -37,7 +37,7 @@ u8 clamp_fan_rpm(unsigned int rpm, __u32 product_id)
 	return (u8)(rpm / 100);
 }
 
-int creatorModeAllowed(__u32 product_id)
+int creator_mode_allowed(__u32 product_id)
 {
 	switch (product_id) {
 	case BLADE_2019_ADV:

--- a/driver/src/fancontrol.c
+++ b/driver/src/fancontrol.c
@@ -16,7 +16,7 @@ int get_max_fan_rpm(__u32 product_id)
 	}
 }
 
-u8 clampFanRPM(unsigned int rpm, __u32 product_id)
+u8 clamp_fan_rpm(unsigned int rpm, __u32 product_id)
 {
 	int max_allowed = get_max_fan_rpm(product_id);
 

--- a/driver/src/fancontrol.h
+++ b/driver/src/fancontrol.h
@@ -26,5 +26,5 @@ u8 clamp_fan_rpm(unsigned int rpm, __u32 product_id);
  * Some laptops are allowed an additional mode called 'creator'
  * which raises just GPU power
  */
-int creatorModeAllowed(__u32 product_id);
+int creator_mode_allowed(__u32 product_id);
 

--- a/driver/src/fancontrol.h
+++ b/driver/src/fancontrol.h
@@ -30,7 +30,7 @@ int get_max_fan_rpm(__u32 product_id);
 /**
  * Clamps input manual fan RPM to what is allowed by the laptop
  */
-__u8 clampFanRPM(unsigned int rpm, __u32 product_id);
+u8 clampFanRPM(unsigned int rpm, __u32 product_id);
 
 
 /**

--- a/driver/src/fancontrol.h
+++ b/driver/src/fancontrol.h
@@ -17,17 +17,6 @@
 #define FAN_RPM_ID  0x01 // ID to control fan RPM
 
 /**
- * Returns the highest valid fan RPM for manual fan control
- *
- * We could through a higher value at the EC, it may even accept it which would
- * be dangerous, so limit it to what we know is safe based on using Synapse.
- *
- * Each model of Blade seems to have a different upper limit, so we require the
- * product ID to set the correct upper bound
- */
-int get_max_fan_rpm(__u32 product_id);
-
-/**
  * Clamps input manual fan RPM to what is allowed by the laptop
  */
 u8 clamp_fan_rpm(unsigned int rpm, __u32 product_id);

--- a/driver/src/fancontrol.h
+++ b/driver/src/fancontrol.h
@@ -30,7 +30,7 @@ int get_max_fan_rpm(__u32 product_id);
 /**
  * Clamps input manual fan RPM to what is allowed by the laptop
  */
-u8 clampFanRPM(unsigned int rpm, __u32 product_id);
+u8 clamp_fan_rpm(unsigned int rpm, __u32 product_id);
 
 
 /**

--- a/driver/src/razer_common.c
+++ b/driver/src/razer_common.c
@@ -263,7 +263,7 @@ static ssize_t power_mode_store(struct device *dev,
 		if (x == 0) {
 			dev_info(dev, "%s", "Enabling Balanced power mode");
 		} else if (x == 2 &&
-			   creatorModeAllowed(laptop->product_id) == 1) {
+			   creator_mode_allowed(laptop->product_id) == 1) {
 			dev_info(dev, "%s", "Enabling Gaming power mode");
 		} else if (x == 1) {
 			dev_info(dev, "%s", "Enabling Gaming power mode");

--- a/driver/src/razer_common.c
+++ b/driver/src/razer_common.c
@@ -141,7 +141,7 @@ static ssize_t fan_rpm_store(struct device *dev, struct device_attribute *attr,
 {
 	struct razer_laptop *laptop = dev_get_drvdata(dev);
 	unsigned long x;
-	__u8 request_fan_speed;
+	u8 request_fan_speed;
 	char buffer[90];
 
 	mutex_lock(&laptop->lock);

--- a/driver/src/razer_common.c
+++ b/driver/src/razer_common.c
@@ -152,7 +152,7 @@ static ssize_t fan_rpm_store(struct device *dev, struct device_attribute *attr,
 		request_fan_speed = 0;
 	}
 	if (x != 0) {
-		request_fan_speed = clampFanRPM(x, laptop->product_id);
+		request_fan_speed = clamp_fan_rpm(x, laptop->product_id);
 		dev_info(dev, "Requesting MANUAL fan at %d RPM",
 			 ((int) request_fan_speed * 100));
 		laptop->fan_rpm = request_fan_speed * 100;

--- a/driver/src/razer_common.c
+++ b/driver/src/razer_common.c
@@ -326,12 +326,7 @@ static int razer_laptop_probe(struct hid_device *hdev,
 		kfree(dev);
 		return -ENODEV;
 	}
-	dev_info(&intf->dev, "Found supported device: %s\n",
-		 getDeviceDescription(dev->product_id));
-	device_create_file(&hdev->dev, &dev_attr_fan_rpm);
-	device_create_file(&hdev->dev, &dev_attr_power_mode);
 
-	hid_set_drvdata(hdev, dev);
 	if (hid_parse(hdev)) {
 		hid_err(hdev, "Failed to parse device!\n");
 		kfree(dev);
@@ -342,6 +337,13 @@ static int razer_laptop_probe(struct hid_device *hdev,
 		kfree(dev);
 		return -ENODEV;
 	}
+
+	hid_set_drvdata(hdev, dev);
+	device_create_file(&hdev->dev, &dev_attr_fan_rpm);
+	device_create_file(&hdev->dev, &dev_attr_power_mode);
+
+	dev_info(&intf->dev, "Found supported device: %s\n",
+		 getDeviceDescription(dev->product_id));
 
 	return 0;
 }


### PR DESCRIPTION
Here are some patches that resolve the names of some functions, as well as use the correct variable type and fix a minor issue that could possibly occur if the device descriptors are not correctly parsed or if userspace races with device probe.
